### PR TITLE
Bug fixes for scenarios around multiple blocks and output file specified.

### DIFF
--- a/lib/libhashcat.js
+++ b/lib/libhashcat.js
@@ -29,7 +29,7 @@ var begin = function () {
         }
 
         proc = new HTMLProcessor(path.dirname(options.htmlFile), null, data);
-
+        var sourceHtml = fs.readFileSync(options.htmlFile, {encoding:'utf8'});
         proc.blocks.forEach(function (block) {
             console.log('-----');
             console.log("Processing block for " + block.dest);
@@ -54,7 +54,7 @@ var begin = function () {
                     fs.writeFileSync(block.dest, minimized);
                 }
                 catch(e){
-                    console.log("ERROR while minifying CSS: ")
+                    console.log("ERROR while minifying CSS: ");
                     console.log(e);
                     return;
                 }
@@ -100,18 +100,12 @@ var begin = function () {
 
                 lockFile.lockSync('lockfile.lock', {retries:10});
 
-                var sourceHtml = fs.readFileSync(options.htmlFile, {encoding:'utf8'});
-
                 if(sourceHtml.length <= 0){
                     console.log("ERROR reading " + options.htmlFile + ", it appears to be empty");
                     return;
                 }
 
-                var result = sourceHtml.replace(blockLine, replacement);
-
-                console.log("Writing to HTML source file");
-                fs.writeFileSync(options.outputHtmlFile, result, 'utf8');
-
+                sourceHtml = sourceHtml.replace(blockLine, replacement);
             }
             catch(e){
                 console.log("ERROR while creating new reference: ");
@@ -124,7 +118,8 @@ var begin = function () {
             }
 
         });
-
+        console.log("Writing to HTML source file");
+        fs.writeFileSync(options.outputHtmlFile, sourceHtml, 'utf8');
         console.log("Hashcat complete")
     });
 };


### PR DESCRIPTION
Fixing bug where multiple blocks in the source file cause the optional argument for output file to not work. 

Now writing to the output file only once.
